### PR TITLE
Update to use zendesk to 3.0.2 to support swift 5.1

### DIFF
--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -10,6 +10,7 @@ import UIKit
 import Foundation
 import ZendeskSDK
 import ZendeskCoreSDK
+import CommonUISDK
 
 @objc(RNZendesk)
 class RNZendesk: RCTEventEmitter {

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -14,7 +14,7 @@ import ZendeskCoreSDK
 @objc(RNZendesk)
 class RNZendesk: RCTEventEmitter {
 
-    override open static func requiresMainQueueSetup() -> Bool {
+    override public static func requiresMainQueueSetup() -> Bool {
         return false;
     }
     
@@ -53,7 +53,7 @@ class RNZendesk: RCTEventEmitter {
     
     @objc(identifyAnonymous:email:)
     func identifyAnonymous(name: String?, email: String?) {
-        var identity = Identity.createAnonymous(name: name, email: email)
+        let identity = Identity.createAnonymous(name: name, email: email)
         Zendesk.instance?.setIdentity(identity)
     }
     
@@ -64,7 +64,7 @@ class RNZendesk: RCTEventEmitter {
         DispatchQueue.main.async {
             let hcConfig = HelpCenterUiConfiguration()
             hcConfig.hideContactSupport = (options["hideContactSupport"] as? Bool) ?? false
-            let helpCenter = HelpCenterUi.buildHelpCenterOverview(withConfigs: [hcConfig])
+            let helpCenter = HelpCenterUi.buildHelpCenterOverviewUi(withConfigs: [hcConfig])
             
             let nvc = UINavigationController(rootViewController: helpCenter)
             UIApplication.shared.keyWindow?.rootViewController?.present(nvc, animated: true, completion: nil)

--- a/react-native-zendesk.podspec
+++ b/react-native-zendesk.podspec
@@ -14,7 +14,8 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => package['repository']['url'], :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,swift}"
+  s.swift_version = '5.0'
 
   s.dependency "React"
-  s.dependency "ZendeskSDK", "~> 2.3.1"
+  s.dependency "ZendeskSDK", "~> 3.0.0"
 end


### PR DESCRIPTION
Swift 5.1 support has been added to the zendesk sdk in version 3.0.2.
Changes required to migrate from zendesk sdk 2.x to 3.x 

Fixes #12 